### PR TITLE
fix to get the branch name

### DIFF
--- a/protocol_update/action.yml
+++ b/protocol_update/action.yml
@@ -14,10 +14,14 @@ inputs:
 
       [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
+  GITHUB_HEAD_REF:
+    description: >
+      The name of the protocol branch that is to be merged.
+    default: ${{ github.event.pull_request.head.ref }}
 runs:
   using: 'docker'
   image: docker://inbobmk/protocols
   entrypoint: '/entrypoint_update.sh'
   env:
     GITHUB_PAT: ${{ inputs.PAT }}
-
+    GITHUB_HEAD_REF: ${{ inputs.GITHUB_HEAD_REF }}


### PR DESCRIPTION
This action used to work with `protocolsource/.github/workflows/update_zenodo_news.yml`, but no longer works since we changed from: 

```
---
on:
  pull_request
...
---

```
to 

```
---
on:
  pull_request_review
...
---

```
To ensure that the variable `$GITHUB_HEAD_REF` is known (i.e. not empty) in the `protocolsource/docker/entrypoint_update.sh`, we need to get it from `github.event.pull_request.head.ref`

This PR makes some changes so that the default input has the correct value.