### PR TITLE
update protocol actions (needs protocolhelper >= 0.8.0)

### DIFF
--- a/protocol_update/README.md
+++ b/protocol_update/README.md
@@ -1,3 +1,5 @@
 # protocol_update
 
-Dedicated Github action to add information on the new protocol to `.zenodo.json` and the general `NEWS.md` in repository `github.com/inbo/protocolsource` by running `protocolhelper` internal functions `update_zenodo()` and `update_news_release()`.
+Dedicated Github action to add information on the new protocol to the general `.zenodo.json` and the general `NEWS.md` in repository `github.com/inbo/protocolsource` by running `protocolhelper` internal functions `update_zenodo()` and `update_news_release()`.
+
+The action also runs the internal function `update_doi()` to add or update the protocol-specific Zenodo DOI.

--- a/protocol_update/action.yml
+++ b/protocol_update/action.yml
@@ -18,6 +18,13 @@ inputs:
     description: >
       The name of the protocol branch that is to be merged.
     default: ${{ github.event.pull_request.head.ref }}
+  ZENODO:
+    description: >
+      Token used to create a new Zenodo deposit or update an existing Zenodo
+      deposit (https://zenodo.org/).
+      The associated DOI will be added or updated in the YAML front matter of
+      the protocol's index.Rmd file.
+    default: ""
 runs:
   using: 'docker'
   image: docker://inbobmk/protocols
@@ -25,3 +32,4 @@ runs:
   env:
     GITHUB_PAT: ${{ inputs.PAT }}
     GITHUB_HEAD_REF: ${{ inputs.GITHUB_HEAD_REF }}
+    ZENODO: ${{ inputs.ZENODO }}

--- a/protocol_website/action.yml
+++ b/protocol_website/action.yml
@@ -17,6 +17,13 @@ inputs:
 
       [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
+  ZENODO:
+    description: >
+      Token used to create a new Zenodo deposit or update an existing Zenodo
+      deposit (https://zenodo.org/).
+      The associated DOI will be added or updated in the YAML front matter of
+      the protocol's index.Rmd file.
+    default: ""
   RECENT_MERGED_BRANCH_NAME:
     description: >
       Name of branch that was merged in the main during the push that triggers this action.
@@ -26,5 +33,6 @@ runs:
   entrypoint: '/entrypoint_website.sh'
   env:
     GITHUB_PAT: ${{ inputs.PAT }}
+    ZENODO: ${{ inputs.ZENODO }}
     GITHUB_REPOSITORY_DEST: ${{ inputs.GITHUB_REPOSITORY_DEST }}
     RECENT_MERGED_BRANCH_NAME: ${{ inputs.RECENT_MERGED_BRANCH_NAME }}


### PR DESCRIPTION
This PR adds the ZENODO token to the protocol actions that need it starting from protocolhelper version 0.8.0.